### PR TITLE
Remove user.discriminator from buildUserDetail

### DIFF
--- a/discord.ts
+++ b/discord.ts
@@ -206,7 +206,7 @@ export class DiscordBot extends EventEmitter {
     }
 
     buildUserDetail(user: User): string {
-        return `[ <@${user.id}> \`${user.id}\` ] **${user.username}#${user.discriminator}**`
+        return `[ <@${user.id}> \`${user.id}\` ] **${user.username}**`
     }
 
     async fetchAuditEntryFor(guild: Guild, user: User, type: AuditLogEvent) {


### PR DESCRIPTION
I've removed user.discriminator from the buildUserDetail function as discord no longer supports discriminators.